### PR TITLE
recovery: fixup `compute displayable item count while drawing`

### DIFF
--- a/recovery_ui/include/recovery_ui/screen_ui.h
+++ b/recovery_ui/include/recovery_ui/screen_ui.h
@@ -169,13 +169,18 @@ class TextMenu : public Menu {
   // The number of displayable items is only known after we started drawing the menu (to consider logo, header, etc.)
   // Make it settable after the menu is created
   void SetMenuHeight(int height) {
-    max_display_items_ = height / draw_funcs_.MenuItemHeight();
-    menu_start_ = std::max(0, (int)selection_ - (int)max_display_items_ + 1);
+    if (!calibrated_height_) {
+      max_display_items_ = height / draw_funcs_.MenuItemHeight();
+      menu_start_ = std::max(0, (int)selection_ - (int)max_display_items_ + 1);
+      calibrated_height_ = true;
+    }
   }
 
  private:
   // The menu is scrollable to display more items. Used on wear devices who have smaller screens.
   const bool wrappable_;
+  // Did we compute our max height already?
+  bool calibrated_height_;
   // The max number of menu items to fit vertically on a screen.
   size_t max_display_items_;
   // The length of each item to fit horizontally on a screen.

--- a/recovery_ui/screen_ui.cpp
+++ b/recovery_ui/screen_ui.cpp
@@ -66,6 +66,7 @@ TextMenu::TextMenu(bool wrappable, size_t max_length,
                    size_t initial_selection, int char_height, const DrawInterface& draw_funcs)
     : Menu(initial_selection, draw_funcs),
       wrappable_(wrappable),
+      calibrated_height_(false),
       max_item_length_(max_length),
       text_headers_(headers),
       char_height_(char_height) {


### PR DESCRIPTION
  menu_start_ was getting overritten at every redraw, making it
  impossible to scroll with Menu::Scroll(int)

Change-Id: I61ad64109cf694918bdd5bac9a6703348eac6d10