### PR TITLE
recovery: fix applying updates

### DIFF
--- a/recovery.cpp
+++ b/recovery.cpp
@@ -254,6 +254,7 @@ static int apply_update_menu(Device* device, RecoveryUI* ui, Device::BuiltinActi
     } else {
       status = ApplyFromStorage(device, volumes[chosen - 1], ui);
     }
+    break;
   }
   return status;
 }


### PR DESCRIPTION
We need to break after applying from either ADB or Storage to return the status of the installation.

Otherwise the log is stuck until you press on the back arrow, you are able to start sideload multiple times and other shenanigans.

Change-Id: I06c9dcf6161dd1a0199417cfed2465914837d795